### PR TITLE
Xzz2l2nu 76x dev

### DIFF
--- a/XZZ2l2nu/cfg/run_xzz2l2nu_76x_cfg_loose_mc.py
+++ b/XZZ2l2nu/cfg/run_xzz2l2nu_76x_cfg_loose_mc.py
@@ -69,18 +69,18 @@ if test==1:
     #selectedComponents = [SingleMuon_Run2015D_Promptv4,SingleElectron_Run2015D_Promptv4]
     #[SingleElectron_Run2015D_Promptv4,SingleElectron_Run2015D_05Oct]
     #selectedComponents = [RSGravToZZToZZinv_narrow_800]
-    selectedComponents = [DYJetsToLL_M50]
+    #selectedComponents = [DYJetsToLL_M50]
     #selectedComponents = signalSamples
-    #selectedComponents = [BulkGravToZZToZlepZinv_narrow_600]
+    selectedComponents = [BulkGravToZZToZlepZinv_narrow_1400]
     #selectedComponents = [BulkGravToZZToZlepZinv_narrow_800]
     #selectedComponents = [WWToLNuQQ, WZTo1L1Nu2Q, WZTo2L2Q, ZZTo2L2Nu]
     #selectedComponents = [ZZTo2L2Nu,DYJetsToLL_M50]
     #selectedComponents = [BulkGravToZZ_narrow_800]
     #selectedComponents = [BulkGravToZZToZlepZhad_narrow_800]
     for c in selectedComponents:
-        c.files = c.files[0]
-        #c.splitFactor = (len(c.files)/10 if len(c.files)>10 else 1)
-        c.splitFactor = 1
+        #c.files = c.files[0]
+        c.splitFactor = (len(c.files)/10 if len(c.files)>10 else 1)
+        #c.splitFactor = 1
         #c.triggers=triggers_1mu_noniso
         #c.triggers=triggers_1e_noniso
 

--- a/XZZ2l2nu/python/analyzers/JetReCalibrator.py
+++ b/XZZ2l2nu/python/analyzers/JetReCalibrator.py
@@ -1,5 +1,5 @@
 import ROOT
-import os, types
+import os, types, copy
 from math import *
 from PhysicsTools.HeppyCore.utils.deltar import *
 
@@ -93,7 +93,25 @@ class JetReCalibrator:
                     p4 -= pfcand.p4()
         return p4
 
-    def correct(self,jet,rho,delta=0,addCorr=False,addShifts=False, metShift=[0,0],type1METCorr=[0,0,0]):
+    def FillType1METCorr(self, jet, rho, raw, corr, metShift, type1METCorr):
+        newpt = jet.pt()*raw*corr
+        if newpt > self.type1METParams['jetPtThreshold']:
+            rawP4forT1 = self.rawP4forType1MET_(jet)
+            if rawP4forT1 and rawP4forT1.Pt()*corr > self.type1METParams['jetPtThreshold']:
+                metShift[0] -= rawP4forT1.Px() * (corr - 1.0/raw)
+                metShift[1] -= rawP4forT1.Py() * (corr - 1.0/raw)
+                if self.calculateType1METCorr:
+                    l1corr = self.getCorrection(jet,rho,delta=0,corrector=self.separateJetCorrectors["L1"]) # FIXME: to check with MET POG, why L1 corrector can not be varied
+                    #print "\tfor jet with raw pt %.5g, eta %.5g, dpx = %.5g, dpy = %.5g" % (
+                    #            jet.pt()*raw, jet.eta(), 
+                    #            rawP4forT1.Px()*(corr - l1corr), 
+                    #            rawP4forT1.Py()*(corr - l1corr))
+                    type1METCorr[0] -= rawP4forT1.Px() * (corr - l1corr) 
+                    type1METCorr[1] -= rawP4forT1.Py() * (corr - l1corr) 
+                    type1METCorr[2] += rawP4forT1.Et() * (corr - l1corr) 
+                    
+
+    def correct(self,jet,rho,delta=0,addCorr=False,addShifts=False, metShift=[0,0],type1METCorr=[0,0,0], type1METCorrUp=[0,0,0], type1METCorrDown=[0,0,0]):
         """Corrects a jet energy (optionally shifting it also by delta times the JEC uncertainty)
 
            If addCorr, set jet.corr to the correction.
@@ -120,32 +138,24 @@ class JetReCalibrator:
                 setattr(jet, "corr"+shift, cshift)
         if corr <= 0:
             return False
-        newpt = jet.pt()*raw*corr
-        if newpt > self.type1METParams['jetPtThreshold']:
-            rawP4forT1 = self.rawP4forType1MET_(jet)
-            if rawP4forT1 and rawP4forT1.Pt()*corr > self.type1METParams['jetPtThreshold']:
-                metShift[0] -= rawP4forT1.Px() * (corr - 1.0/raw)
-                metShift[1] -= rawP4forT1.Py() * (corr - 1.0/raw)
-                if self.calculateType1METCorr:
-                    l1corr = self.getCorrection(jet,rho,delta=0,corrector=self.separateJetCorrectors["L1"])
-                    #print "\tfor jet with raw pt %.5g, eta %.5g, dpx = %.5g, dpy = %.5g" % (
-                    #            jet.pt()*raw, jet.eta(), 
-                    #            rawP4forT1.Px()*(corr - l1corr), 
-                    #            rawP4forT1.Py()*(corr - l1corr))
-                    type1METCorr[0] -= rawP4forT1.Px() * (corr - l1corr) 
-                    type1METCorr[1] -= rawP4forT1.Py() * (corr - l1corr) 
-                    type1METCorr[2] += rawP4forT1.Et() * (corr - l1corr) 
+
+        self.FillType1METCorr(jet, rho, raw, corr, metShift, type1METCorr)
+        self.FillType1METCorr(jet, rho, raw, jet.corrJECUp, [0.,0.], type1METCorrUp)
+        self.FillType1METCorr(jet, rho, raw, jet.corrJECDown, [0.,0.], type1METCorrDown)
+
         jet.setCorrP4(jet.p4() * (corr * raw))
         return True
 
-    def correctAll(self,jets,rho,delta=0, addCorr=False, addShifts=False, metShift=[0.,0.], type1METCorr=[0.,0.,0.]):
+    def correctAll(self,jets,rho,delta=0, addCorr=False, addShifts=False, metShift=[0.,0.], type1METCorr=[0.,0.,0.], type1METCorrUp=[0.,0.,0.], type1METCorrDown=[0.,0.,0.]):
         """Applies 'correct' to all the jets, discard the ones that have bad corrections (corrected pt <= 0)"""
         badJets = []
         if metShift     != [0.,0.   ]: raise RuntimeError, "input metShift tuple is not initialized to zeros"
         if type1METCorr != [0.,0.,0.]: raise RuntimeError, "input type1METCorr tuple is not initialized to zeros"
         for j in jets:
-            ok = self.correct(j,rho,delta,addCorr=addCorr,addShifts=addShifts,metShift=metShift,type1METCorr=type1METCorr)
+            ok = self.correct(j,rho,delta,addCorr=addCorr,addShifts=addShifts,metShift=metShift,
+                              type1METCorr=type1METCorr, type1METCorrUp=type1METCorrUp, type1METCorrDown=type1METCorrDown)
             if not ok: badJets.append(j)
+
         if len(badJets) > 0:
             print "Warning: %d out of %d jets flagged bad by JEC." % (len(badJets), len(jets))
         for bj in badJets:

--- a/XZZ2l2nu/python/analyzers/XZZMETAnalyzer.py
+++ b/XZZ2l2nu/python/analyzers/XZZMETAnalyzer.py
@@ -180,16 +180,24 @@ class XZZMETAnalyzer( Analyzer ):
           self.met = self.handles['met'].product()[0]
           if self.cfg_ana.doMetNoPU: self.metNoPU = self.handles['nopumet'].product()[0]
 
+        self.met_miniAod = copy.deepcopy(self.met)
+        setattr(event,"met_miniAod"+self.cfg_ana.collectionPostFix, self.met_miniAod)
+
         if self.recalibrateMET == "type1":
           type1METCorr = getattr(event, 'type1METCorr'+self.jetAnalyzerPostFix)
           self.type1METCorrector.correct(self.met, type1METCorr)
+          self.met_JEC = copy.deepcopy(self.met)
+          setattr(event,"met_JEC"+self.cfg_ana.collectionPostFix, self.met_JEC)
+
         elif self.recalibrateMET == True:
           deltaMetJEC = getattr(event, 'deltaMetFromJEC'+self.jetAnalyzerPostFix)
           self.applyDeltaMet(self.met, deltaMetJEC)
+
         if self.applyJetSmearing:
           deltaMetSmear = getattr(event, 'deltaMetFromJetSmearing'+self.jetAnalyzerPostFix)
           self.applyDeltaMet(self.met, deltaMetSmear)
-
+          self.met_JECJER = copy.deepcopy(self.met)
+          setattr(event,"met_JECJER"+self.cfg_ana.collectionPostFix, self.met_JECJER)
 
         #Shifted METs: to be re-enabled after updates to MiniAOD pass 2
         #Uncertainties defined in https://github.com/cms-sw/cmssw/blob/CMSSW_7_2_X/DataFormats/PatCandidates/interface/MET.h#L168

--- a/XZZ2l2nu/python/analyzers/XZZTypes.py
+++ b/XZZ2l2nu/python/analyzers/XZZTypes.py
@@ -59,3 +59,4 @@ corrJetType = NTupleObjectType("corrJetType", baseObjectTypes=[JetType], variabl
     NTupleVariable("jec_corrDown",   lambda x : x.corrJECDown if hasattr(x,"corrJECDown") else  1.0 ,float), 
     NTupleVariable("jer_corr",   lambda x : x.corrJER if hasattr(x,"corrJER") else  1.0 ,float), # JER correction factor
 ])
+

--- a/XZZ2l2nu/python/analyzers/coreXZZ_cff.py
+++ b/XZZ2l2nu/python/analyzers/coreXZZ_cff.py
@@ -136,6 +136,7 @@ metAna = cfg.Analyzer(
     doMetNoEle = False,
     doMetNoPhoton = False,
     recalibrate = "type1", # or "type1", or True, or False
+    doMetShiftFromJEC = True, # only works with recalibrate on
     applyJetSmearing = False, # does nothing unless the jet smearing is turned on in the jet analyzer
     old74XMiniAODs = False, # set to True to get the correct Raw MET when running on old 74X MiniAODs
     jetAnalyzerPostFix = "",

--- a/XZZ2l2nu/python/analyzers/treeXZZ_cff.py
+++ b/XZZ2l2nu/python/analyzers/treeXZZ_cff.py
@@ -27,6 +27,8 @@ jetTreeProducer = cfg.Analyzer(
          "met" : NTupleObject("met", metType, help="PF E_{T}^{miss}, after full type 1 corrections"),
          "met_miniAod" : NTupleObject("met_raw", metType, help="PF E_{T}^{miss}, after type 1 corrections in miniAOD"),
          "met_JEC" : NTupleObject("met_JEC", metType, help="PF E_{T}^{miss}, after type 1 corrections with new 76X JEC added"),
+         "met_JECUp" : NTupleObject("met_JECUp", metType, help="PF E_{T}^{miss}, after type 1 corrections with new 76X JEC up"),
+         "met_JECDown" : NTupleObject("met_JECDown", metType, help="PF E_{T}^{miss}, after type 1 corrections with new 76X JEC down"),
          "met_JECJER" : NTupleObject("met_JECJER", metType, mcOnly=True, help="PF E_{T}^{miss}, after type 1 corrections with JEC+JER jets"),
      },
 
@@ -54,6 +56,11 @@ vvTreeProducer = cfg.Analyzer(
      ],
      globalObjects =  {
          "met" : NTupleObject("met", metType, help="PF E_{T}^{miss}, after type 1 corrections"),
+         "met_miniAod" : NTupleObject("met_raw", metType, help="PF E_{T}^{miss}, after type 1 corrections in miniAOD"),
+         "met_JEC" : NTupleObject("met_JEC", metType, help="PF E_{T}^{miss}, after type 1 corrections with new 76X JEC added"),
+         "met_JECUp" : NTupleObject("met_JECUp", metType, help="PF E_{T}^{miss}, after type 1 corrections with new 76X JEC up"),
+         "met_JECDown" : NTupleObject("met_JECDown", metType, help="PF E_{T}^{miss}, after type 1 corrections with new 76X JEC down"),
+         "met_JECJER" : NTupleObject("met_JECJER", metType, mcOnly=True, help="PF E_{T}^{miss}, after type 1 corrections with JEC+JER jets"),
      },
 
      collections = {

--- a/XZZ2l2nu/python/analyzers/treeXZZ_cff.py
+++ b/XZZ2l2nu/python/analyzers/treeXZZ_cff.py
@@ -24,7 +24,10 @@ jetTreeProducer = cfg.Analyzer(
          NTupleVariable("nVert",  lambda ev: len(ev.goodVertices), int, help="Number of good vertices"), 
      ],
      globalObjects =  {
-         "met" : NTupleObject("met", metType, help="PF E_{T}^{miss}, after type 1 corrections"),
+         "met" : NTupleObject("met", metType, help="PF E_{T}^{miss}, after full type 1 corrections"),
+         "met_miniAod" : NTupleObject("met_raw", metType, help="PF E_{T}^{miss}, after type 1 corrections in miniAOD"),
+         "met_JEC" : NTupleObject("met_JEC", metType, help="PF E_{T}^{miss}, after type 1 corrections with new 76X JEC added"),
+         "met_JECJER" : NTupleObject("met_JECJER", metType, mcOnly=True, help="PF E_{T}^{miss}, after type 1 corrections with JEC+JER jets"),
      },
 
      collections = {

--- a/XZZ2l2nu/scripts/stack_dtmc.py
+++ b/XZZ2l2nu/scripts/stack_dtmc.py
@@ -6,16 +6,17 @@ from CMGTools.XZZ2l2nu.plotting.TreePlotter import TreePlotter
 from CMGTools.XZZ2l2nu.plotting.MergedPlotter import MergedPlotter
 from CMGTools.XZZ2l2nu.plotting.StackPlotter import StackPlotter
 
-#cutChain='loosecut'
+cutChain='loosecut'
 #cutChain='tightzpt100'
 #cutChain='tightzpt100met100'
 #cutChain='tightzpt100met100dphi'
 #cutChain='tightmet250dphi'
 #cutChain='zjetscut'
-cutChain='zjetscutmet50'
+#cutChain='zjetscutmet50'
 
 outdir='plots'
-indir="/afs/cern.ch/work/h/heli/public/XZZ/76X"
+#indir="/afs/cern.ch/work/h/heli/public/XZZ/76X"
+indir="/afs/cern.ch/work/m/mewu/public/76X_new"
 lumi=2.169126704526
 sepSig=True
 LogY=True


### PR DESCRIPTION
- Different MET available to access in the tree of the ntuples produced.
- for the JEC up/down propagated to MET: the simplest way implemented, i.e., all JEC jets used for MET are scaled up to get the met_JECUp, similar for met_JECDown.
